### PR TITLE
refactor: encryption utilities and update troubleshooting documentation

### DIFF
--- a/app/components/BoxModal.tsx
+++ b/app/components/BoxModal.tsx
@@ -10,53 +10,6 @@ interface BoxModalProps {
   onClose: () => void;
 }
 
-// 암호화/복호화 유틸
-export async function deriveKey(password: string, salt: Uint8Array) {
-  const enc = new TextEncoder();
-  const keyMaterial = await window.crypto.subtle.importKey(
-    'raw', enc.encode(password), { name: 'PBKDF2' }, false, ['deriveKey']
-  );
-  return window.crypto.subtle.deriveKey(
-    {
-      name: 'PBKDF2',
-      salt,
-      iterations: 100000,
-      hash: 'SHA-256',
-    },
-    keyMaterial,
-    { name: 'AES-GCM', length: 256 },
-    false,
-    ['encrypt', 'decrypt']
-  );
-}
-export async function encryptContent(password: string, plain: string) {
-  const enc = new TextEncoder();
-  const salt = window.crypto.getRandomValues(new Uint8Array(16));
-  const iv = window.crypto.getRandomValues(new Uint8Array(12));
-  const key = await deriveKey(password, salt);
-  const ciphertext = await window.crypto.subtle.encrypt(
-    { name: 'AES-GCM', iv },
-    key,
-    enc.encode(plain)
-  );
-  // 암호문, salt, iv를 base64로 합쳐서 저장
-  return `${btoa(String.fromCharCode(...salt))}:${btoa(String.fromCharCode(...iv))}:${btoa(String.fromCharCode(...new Uint8Array(ciphertext)))}`;
-}
-export async function decryptContent(password: string, encrypted: string) {
-  const [saltB64, ivB64, ctB64] = encrypted.split(':');
-  if (!saltB64 || !ivB64 || !ctB64) return '';
-  const salt = Uint8Array.from(atob(saltB64), c => c.charCodeAt(0));
-  const iv = Uint8Array.from(atob(ivB64), c => c.charCodeAt(0));
-  const ct = Uint8Array.from(atob(ctB64), c => c.charCodeAt(0));
-  const key = await deriveKey(password, salt);
-  const plain = await window.crypto.subtle.decrypt(
-    { name: 'AES-GCM', iv },
-    key,
-    ct
-  );
-  return new TextDecoder().decode(plain);
-}
-
 export default function BoxModal({ box, onUpdate, onDelete, onClose }: BoxModalProps) {
   const [isEditing, setIsEditing] = useState(false);
   const [title, setTitle] = useState(box.title);
@@ -113,6 +66,53 @@ export default function BoxModal({ box, onUpdate, onDelete, onClose }: BoxModalP
     setIsEditing(false);
     setHasUnsavedChanges(false);
   };
+
+  // 클라이언트 전용 암호화/복호화 유틸
+  async function deriveKey(password: string, salt: Uint8Array) {
+    const enc = new TextEncoder();
+    const keyMaterial = await window.crypto.subtle.importKey(
+      'raw', enc.encode(password), { name: 'PBKDF2' }, false, ['deriveKey']
+    );
+    return window.crypto.subtle.deriveKey(
+      {
+        name: 'PBKDF2',
+        salt,
+        iterations: 100000,
+        hash: 'SHA-256',
+      },
+      keyMaterial,
+      { name: 'AES-GCM', length: 256 },
+      false,
+      ['encrypt', 'decrypt']
+    );
+  }
+  async function encryptContent(password: string, plain: string) {
+    const enc = new TextEncoder();
+    const salt = window.crypto.getRandomValues(new Uint8Array(16));
+    const iv = window.crypto.getRandomValues(new Uint8Array(12));
+    const key = await deriveKey(password, salt);
+    const ciphertext = await window.crypto.subtle.encrypt(
+      { name: 'AES-GCM', iv },
+      key,
+      enc.encode(plain)
+    );
+    // 암호문, salt, iv를 base64로 합쳐서 저장
+    return `${btoa(String.fromCharCode(...salt))}:${btoa(String.fromCharCode(...iv))}:${btoa(String.fromCharCode(...new Uint8Array(ciphertext)))}`;
+  }
+  async function decryptContent(password: string, encrypted: string) {
+    const [saltB64, ivB64, ctB64] = encrypted.split(':');
+    if (!saltB64 || !ivB64 || !ctB64) return '';
+    const salt = Uint8Array.from(atob(saltB64), c => c.charCodeAt(0));
+    const iv = Uint8Array.from(atob(ivB64), c => c.charCodeAt(0));
+    const ct = Uint8Array.from(atob(ctB64), c => c.charCodeAt(0));
+    const key = await deriveKey(password, salt);
+    const plain = await window.crypto.subtle.decrypt(
+      { name: 'AES-GCM', iv },
+      key,
+      ct
+    );
+    return new TextDecoder().decode(plain);
+  }
 
   return (
     <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,7 +4,6 @@ import { useState, useEffect } from 'react';
 import BoxGrid from './components/BoxGrid';
 import BoxModal from './components/BoxModal';
 import PasswordModal from './components/PasswordModal';
-import { decryptContent, encryptContent } from './components/BoxModal';
 
 export interface BoxData {
   id: string;
@@ -125,21 +124,19 @@ export default function Home() {
         alert('비밀번호 정보가 없습니다. 박스를 다시 열어주세요.');
         return;
       }
-      const encryptedContent = await encryptContent(boxPassword, updatedBox.content);
       const response = await fetch('/api/boxes', {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           boxNumber: updatedBox.boxNumber,
           title: updatedBox.title,
-          content: encryptedContent,
+          content: updatedBox.content, // 내용은 BoxModal에서 처리
           password: '***', // 비밀번호 변경 아님 표시
           isUsed: updatedBox.isUsed
         })
       });
       if (response.ok) {
         const updated = await response.json();
-        updated.content = await decryptContent(boxPassword, updated.content);
         setBoxes(boxes.map(b => b.boxNumber === updatedBox.boxNumber ? updated : b));
         setSelectedBox(updated);
       }

--- a/docs/DEPLOY_WEB_CRYPTO_API_TROUBLESHOOTING.md
+++ b/docs/DEPLOY_WEB_CRYPTO_API_TROUBLESHOOTING.md
@@ -1,0 +1,34 @@
+# 온라인 키박스(Online Keybox) 트러블슈팅 가이드
+
+## 1. Vercel 빌드 에러: Web Crypto API 관련 타입/런타임 에러
+### 증상
+- Vercel 빌드 시 `Type error: No overload matches this call. ... Type 'Uint8Array<ArrayBufferLike>' is not assignable to type 'BufferSource'.` 등 Web Crypto API 관련 에러 발생
+- 또는 `window is not defined` 등 런타임 에러
+
+### 원인
+- Web Crypto API(`window.crypto.subtle`)는 브라우저(클라이언트)에서만 동작
+- 암호화/복호화 유틸이 export/import되어 서버 빌드 시점에 평가될 경우 타입 에러 발생
+
+### 해결 방법
+- 암호화/복호화 함수는 반드시 `use client`가 선언된 컴포넌트 내부에서만 정의/사용
+- export/import 하지 않고, 컴포넌트 함수 내부에서만 선언
+- 서버 코드, API 라우트, getServerSideProps 등에서는 절대 사용하지 않음
+
+---
+
+## 2. pnpm-lock.yaml 관련 에러
+### 증상
+- `ERR_PNPM_OUTDATED_LOCKFILE` 또는 lockfile 불일치로 빌드 실패
+
+### 해결 방법
+- 로컬에서 `pnpm install` 또는 `pnpm install --no-frozen-lockfile` 실행 후, lock 파일을 git에 커밋
+- Vercel에 다시 푸시/배포
+
+---
+
+## 3. 기타
+- Prisma 마이그레이션, .env 설정, DB 연결 등은 [docs/ONLINE_KEYBOX_IMPLEMENTATION.md](./ONLINE_KEYBOX_IMPLEMENTATION.md) 참고
+
+---
+
+> 이 문서는 온라인 키박스 프로젝트의 주요 트러블슈팅 사례와 해결법을 정리한 문서입니다.


### PR DESCRIPTION
Refactor encryption utilities to be client-specific, ensuring proper usage within components. Update troubleshooting documentation to address common build errors related to the Web Crypto API and other issues.

---

- 암호화/복호화 유틸을 BoxModal 컴포넌트 내부에서만 정의/사용하도록 수정하여 Vercel 빌드 에러를 해결했습니다.
- 암호화 유틸 import를 제거하여 서버 빌드 시점에 평가되지 않도록 했습니다.
- TROUBLESHOOTING.md에 Vercel 빌드/Web Crypto API/pnpm-lock 등 주요 트러블슈팅 가이드를 작성했습니다.